### PR TITLE
Fix missing PDF path

### DIFF
--- a/lib/book_row.dart
+++ b/lib/book_row.dart
@@ -34,12 +34,18 @@ class BookRow extends StatelessWidget {
             Expanded(
               child: GestureDetector(
                 onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => PDFViewerScreen(filePath: book.filePath),
-                    ),
-                  );
+                  if (book.filePath.isNotEmpty) {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => PDFViewerScreen(filePath: book.filePath),
+                      ),
+                    );
+                  } else {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('No PDF available for this book')),
+                    );
+                  }
                 },
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -15,7 +15,7 @@ class Book {
   late String coverTitle;
   late String author;
   late double progress;
-  late String filePath;
+  String filePath = '';
 
   // One-to-many relationships
   final highlights = IsarLinks<Highlight>();


### PR DESCRIPTION
## Summary
- prevent late initialization error by giving Book a default file path
- show a message if book has no PDF when tapped

## Testing
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e3c05e954832ba7e9e840f3cb2d3c