### PR TITLE
Add book edit & highlight list features

### DIFF
--- a/lib/book_row.dart
+++ b/lib/book_row.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:kindle_clone_v2/models/book.dart';
 import 'package:kindle_clone_v2/screens/pdf_viewer_screen.dart';
+import 'package:provider/provider.dart';
+import 'providers/book_provider.dart';
+import 'screens/edit_book_screen.dart';
+import 'screens/book_highlights_screen.dart';
 
 class BookRow extends StatelessWidget {
   final Book book;
@@ -101,6 +105,40 @@ class BookRow extends StatelessWidget {
                   ],
                 ),
               ),
+            ),
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                switch (value) {
+                  case 'edit':
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => EditBookScreen(book: book),
+                      ),
+                    );
+                    break;
+                  case 'highlights':
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => BookHighlightsScreen(book: book),
+                      ),
+                    );
+                    break;
+                  case 'delete':
+                    context.read<BookProvider>().deleteBook(book);
+                    break;
+                }
+              },
+              itemBuilder:
+                  (context) => const [
+                    PopupMenuItem(value: 'edit', child: Text('Edit details')),
+                    PopupMenuItem(
+                      value: 'highlights',
+                      child: Text('Show highlights'),
+                    ),
+                    PopupMenuItem(value: 'delete', child: Text('Delete')),
+                  ],
             ),
           ],
         ),

--- a/lib/providers/book_provider.dart
+++ b/lib/providers/book_provider.dart
@@ -23,4 +23,21 @@ class BookProvider extends ChangeNotifier {
     _books.add(book);
     notifyListeners();
   }
+
+  /// Update [book] in the repository and local cache.
+  Future<void> updateBook(Book book) async {
+    await _repository.updateBook(book);
+    final index = _books.indexWhere((b) => b.id == book.id);
+    if (index != -1) {
+      _books[index] = book;
+    }
+    notifyListeners();
+  }
+
+  /// Delete [book] from the repository and local cache.
+  Future<void> deleteBook(Book book) async {
+    await _repository.deleteBook(book);
+    _books.removeWhere((b) => b.id == book.id);
+    notifyListeners();
+  }
 }

--- a/lib/repositories/book_repository.dart
+++ b/lib/repositories/book_repository.dart
@@ -22,10 +22,11 @@ class BookRepository {
 
   Future<Isar> _initDb() async {
     final Directory dir = await getApplicationDocumentsDirectory();
-    return Isar.open(
-      [BookSchema, HighlightSchema, ThoughtSchema],
-      directory: dir.path,
-    );
+    return Isar.open([
+      BookSchema,
+      HighlightSchema,
+      ThoughtSchema,
+    ], directory: dir.path);
   }
 
   /// Fetch all books stored in the database.
@@ -39,6 +40,23 @@ class BookRepository {
     final isar = await _isar;
     await isar.writeTxn(() async {
       await isar.books.put(book);
+    });
+  }
+
+  /// Update an existing [book] in the database.
+  Future<void> updateBook(Book book) async {
+    final isar = await _isar;
+    await isar.writeTxn(() async {
+      await isar.books.put(book);
+    });
+  }
+
+  /// Remove [book] from the database.
+  Future<void> deleteBook(Book book) async {
+    if (book.id == null) return;
+    final isar = await _isar;
+    await isar.writeTxn(() async {
+      await isar.books.delete(book.id!);
     });
   }
 
@@ -56,7 +74,10 @@ class BookRepository {
   Future<List<Highlight>> getHighlightsForBook(Book book) async {
     final isar = await _isar;
     if (book.id == null) return [];
-    return isar.highlights.filter().book((q) => q.idEqualTo(book.id!)).findAll();
+    return isar.highlights
+        .filter()
+        .book((q) => q.idEqualTo(book.id!))
+        .findAll();
   }
 
   /// Delete the given [highlight].
@@ -67,4 +88,3 @@ class BookRepository {
     });
   }
 }
-

--- a/lib/screens/book_highlights_screen.dart
+++ b/lib/screens/book_highlights_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../models/book.dart';
+import '../models/highlight.dart';
+import '../repositories/book_repository.dart';
+import 'pdf_viewer_screen.dart';
+
+class BookHighlightsScreen extends StatefulWidget {
+  final Book book;
+  const BookHighlightsScreen({super.key, required this.book});
+
+  @override
+  State<BookHighlightsScreen> createState() => _BookHighlightsScreenState();
+}
+
+class _BookHighlightsScreenState extends State<BookHighlightsScreen> {
+  final BookRepository _repository = BookRepository.instance;
+  List<Highlight> _highlights = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHighlights();
+  }
+
+  Future<void> _loadHighlights() async {
+    final items = await _repository.getHighlightsForBook(widget.book);
+    setState(() {
+      _highlights = items;
+    });
+  }
+
+  void _openHighlight(Highlight h) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder:
+            (_) => PDFViewerScreen(
+              bookDetail: widget.book,
+              initialPage: h.pageNumber,
+            ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Highlights')),
+      body: ListView.builder(
+        itemCount: _highlights.length,
+        itemBuilder: (context, index) {
+          final h = _highlights[index];
+          return ListTile(
+            title: Text(h.highlightText),
+            subtitle: Text('Page ${h.pageNumber}'),
+            onTap: () => _openHighlight(h),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/edit_book_screen.dart
+++ b/lib/screens/edit_book_screen.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../models/book.dart';
+import '../providers/book_provider.dart';
+
+class EditBookScreen extends StatefulWidget {
+  final Book book;
+  const EditBookScreen({super.key, required this.book});
+
+  @override
+  State<EditBookScreen> createState() => _EditBookScreenState();
+}
+
+class _EditBookScreenState extends State<EditBookScreen> {
+  late TextEditingController _titleController;
+  late TextEditingController _authorController;
+
+  @override
+  void initState() {
+    super.initState();
+    _titleController = TextEditingController(text: widget.book.title);
+    _authorController = TextEditingController(text: widget.book.author);
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _authorController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    widget.book.title = _titleController.text;
+    widget.book.author = _authorController.text;
+    context.read<BookProvider>().updateBook(widget.book);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Book')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: _titleController,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _authorController,
+              decoration: const InputDecoration(labelText: 'Author'),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(onPressed: _save, child: const Text('Save')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -7,8 +7,13 @@ import 'package:flutter/services.dart';
 
 class PDFViewerScreen extends StatefulWidget {
   final Book bookDetail; // Can also be a URL
+  final int? initialPage;
 
-  PDFViewerScreen({required this.bookDetail});
+  const PDFViewerScreen({
+    super.key,
+    required this.bookDetail,
+    this.initialPage,
+  });
 
   @override
   _PDFViewerScreenState createState() => _PDFViewerScreenState();
@@ -28,8 +33,7 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
 
   Future<void> _loadHighlights() async {
     if (widget.bookDetail.id != null) {
-      final items =
-          await _repository.getHighlightsForBook(widget.bookDetail);
+      final items = await _repository.getHighlightsForBook(widget.bookDetail);
       setState(() {
         _highlights = items;
       });
@@ -37,12 +41,13 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
   }
 
   Future<void> _addHighlight(int pageNumber, List<HighlightArea> rects) async {
-    final highlight = Highlight()
-      ..pageNumber = pageNumber
-      ..highlightText = _currentSelection
-      ..color = '#FFFF00'
-      ..timestamp = DateTime.now()
-      ..rects = rects;
+    final highlight =
+        Highlight()
+          ..pageNumber = pageNumber
+          ..highlightText = _currentSelection
+          ..color = '#FFFF00'
+          ..timestamp = DateTime.now()
+          ..rects = rects;
     await _repository.addHighlight(widget.bookDetail, highlight);
     setState(() {
       _highlights.add(highlight);
@@ -52,28 +57,27 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
   void _onHighlightTap(Highlight highlight) async {
     final result = await showModalBottomSheet<String>(
       context: context,
-      builder: (context) => SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.copy),
-              title: const Text('Copy'),
-              onTap: () => Navigator.pop(context, 'copy'),
+      builder:
+          (context) => SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ListTile(
+                  leading: const Icon(Icons.copy),
+                  title: const Text('Copy'),
+                  onTap: () => Navigator.pop(context, 'copy'),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.delete),
+                  title: const Text('Remove'),
+                  onTap: () => Navigator.pop(context, 'remove'),
+                ),
+              ],
             ),
-            ListTile(
-              leading: const Icon(Icons.delete),
-              title: const Text('Remove'),
-              onTap: () => Navigator.pop(context, 'remove'),
-            ),
-          ],
-        ),
-      ),
+          ),
     );
     if (result == 'copy') {
-      await Clipboard.setData(
-        ClipboardData(text: highlight.highlightText),
-      );
+      await Clipboard.setData(ClipboardData(text: highlight.highlightText));
     } else if (result == 'remove') {
       await _repository.deleteHighlight(highlight);
       setState(() {
@@ -144,6 +148,7 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
       appBar: AppBar(title: Text(widget.bookDetail.title)),
       body: PdfViewer.file(
         widget.bookDetail.filePath,
+        initialPageNumber: widget.initialPage ?? 1,
         params: PdfViewerParams(
           enableTextSelection: true,
           perPageSelectableRegionInjector: (context, child, page, pageRect) {
@@ -162,22 +167,23 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
                 ..._highlights
                     .where((h) => h.pageNumber == page.pageNumber)
                     .expand(
-                  (h) => h.rects.map(
-                    (r) => Positioned.fromRect(
-                      rect: Rect.fromLTWH(
-                        r.left * pageRect.width,
-                        r.top * pageRect.height,
-                        r.width * pageRect.width,
-                        r.height * pageRect.height,
-                      ),
-                      child: GestureDetector(
-                        onTap: () => _onHighlightTap(h),
-                        child:
-                            Container(color: Colors.yellow.withOpacity(0.4)),
+                      (h) => h.rects.map(
+                        (r) => Positioned.fromRect(
+                          rect: Rect.fromLTWH(
+                            r.left * pageRect.width,
+                            r.top * pageRect.height,
+                            r.width * pageRect.width,
+                            r.height * pageRect.height,
+                          ),
+                          child: GestureDetector(
+                            onTap: () => _onHighlightTap(h),
+                            child: Container(
+                              color: Colors.yellow.withOpacity(0.4),
+                            ),
+                          ),
+                        ),
                       ),
                     ),
-                  ),
-                ),
               ],
             );
           },


### PR DESCRIPTION
## Summary
- add update/delete methods to repository and provider
- add meatball popup menu to each book row
- implement EditBookScreen for modifying book metadata
- implement BookHighlightsScreen to list all highlights and jump to them
- allow PDFViewerScreen to open at a specific page

## Testing
- `dart format lib/repositories/book_repository.dart lib/providers/book_provider.dart lib/book_row.dart lib/screens/edit_book_screen.dart lib/screens/book_highlights_screen.dart lib/screens/pdf_viewer_screen.dart`
- `flutter analyze` *(fails: Proxy failed to establish tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_685cbb0206e8832ba368eb67f599650b