### PR TITLE
Add last read tracking and colorful progress bar

### DIFF
--- a/lib/book_library_page.dart
+++ b/lib/book_library_page.dart
@@ -59,7 +59,8 @@ class _BookLibraryPageState extends State<BookLibraryPage> {
           ..title = fileName
           ..author = 'Uploaded PDF'
           ..filePath = newFilePath
-          ..progress = 0.0;
+          ..progress = 0.0
+          ..lastRead = DateTime.now();
 
         await context.read<BookProvider>().addBook(newBook);
         print('Book added: $newBook');
@@ -101,8 +102,20 @@ class _BookLibraryPageState extends State<BookLibraryPage> {
               const SizedBox(height: 8),
 
               // Render the list of books from the provider
-              for (final book in context.watch<BookProvider>().books)
-                BookRow(book: book),
+              Builder(
+                builder: (context) {
+                  final books = context.watch<BookProvider>().books;
+                  return Column(
+                    children: List.generate(
+                      books.length,
+                      (index) => BookRow(
+                        book: books[index],
+                        isLastRead: index == 0,
+                      ),
+                    ),
+                  );
+                },
+              ),
             ],
           ),
         ),

--- a/lib/book_row.dart
+++ b/lib/book_row.dart
@@ -8,8 +8,9 @@ import 'screens/book_highlights_screen.dart';
 
 class BookRow extends StatelessWidget {
   final Book book;
+  final bool isLastRead;
 
-  const BookRow({super.key, required this.book});
+  const BookRow({super.key, required this.book, required this.isLastRead});
 
   @override
   Widget build(BuildContext context) {
@@ -75,7 +76,7 @@ class BookRow extends StatelessWidget {
                     if (!book.progress.isNaN) ...[
                       const SizedBox(height: 8),
                       Text(
-                        book.progress.toString(),
+                        '${(book.progress * 100).toStringAsFixed(0)}%',
                         style: const TextStyle(
                           fontSize: 13,
                           color: Colors.black54,
@@ -84,12 +85,7 @@ class BookRow extends StatelessWidget {
                       const SizedBox(height: 4),
                       ClipRRect(
                         borderRadius: BorderRadius.circular(4),
-                        child: LinearProgressIndicator(
-                          value: book.progress,
-                          minHeight: 4,
-                          backgroundColor: Colors.grey.shade300,
-                          color: Colors.grey.shade700,
-                        ),
+                        child: _buildProgressBar(),
                       ),
                     ]
                   ],
@@ -137,6 +133,35 @@ class BookRow extends StatelessWidget {
           child: Divider(height: 1, thickness: 0.5),
         ),
       ],
+    );
+  }
+
+  Widget _buildProgressBar() {
+    final bar = LinearProgressIndicator(
+      value: book.progress,
+      minHeight: 4,
+      backgroundColor: Colors.grey.shade300,
+      color: Colors.grey.shade700,
+    );
+
+    if (!isLastRead) {
+      return bar;
+    }
+
+    return ShaderMask(
+      shaderCallback: (rect) => const LinearGradient(
+        colors: [
+          Colors.red,
+          Colors.orange,
+          Colors.yellow,
+          Colors.green,
+          Colors.blue,
+          Colors.indigo,
+          Colors.purple,
+        ],
+      ).createShader(rect),
+      blendMode: BlendMode.srcIn,
+      child: bar,
     );
   }
 }

--- a/lib/models/book.dart
+++ b/lib/models/book.dart
@@ -15,6 +15,7 @@ class Book {
   late String coverTitle;
   late String author;
   late double progress;
+  DateTime? lastRead;
   String filePath = '';
 
   // One-to-many relationships

--- a/lib/models/book.g.dart
+++ b/lib/models/book.g.dart
@@ -32,13 +32,18 @@ const BookSchema = CollectionSchema(
       name: r'filePath',
       type: IsarType.string,
     ),
-    r'progress': PropertySchema(
+    r'lastRead': PropertySchema(
       id: 3,
+      name: r'lastRead',
+      type: IsarType.dateTime,
+    ),
+    r'progress': PropertySchema(
+      id: 4,
       name: r'progress',
       type: IsarType.double,
     ),
     r'title': PropertySchema(
-      id: 4,
+      id: 5,
       name: r'title',
       type: IsarType.string,
     )
@@ -106,8 +111,9 @@ void _bookSerialize(
   writer.writeString(offsets[0], object.author);
   writer.writeString(offsets[1], object.coverTitle);
   writer.writeString(offsets[2], object.filePath);
-  writer.writeDouble(offsets[3], object.progress);
-  writer.writeString(offsets[4], object.title);
+  writer.writeDateTime(offsets[3], object.lastRead);
+  writer.writeDouble(offsets[4], object.progress);
+  writer.writeString(offsets[5], object.title);
 }
 
 Book _bookDeserialize(
@@ -121,8 +127,9 @@ Book _bookDeserialize(
   object.coverTitle = reader.readString(offsets[1]);
   object.filePath = reader.readString(offsets[2]);
   object.id = id;
-  object.progress = reader.readDouble(offsets[3]);
-  object.title = reader.readString(offsets[4]);
+  object.lastRead = reader.readDateTimeOrNull(offsets[3]);
+  object.progress = reader.readDouble(offsets[4]);
+  object.title = reader.readString(offsets[5]);
   return object;
 }
 
@@ -140,8 +147,10 @@ P _bookDeserializeProp<P>(
     case 2:
       return (reader.readString(offset)) as P;
     case 3:
-      return (reader.readDouble(offset)) as P;
+      return (reader.readDateTimeOrNull(offset)) as P;
     case 4:
+      return (reader.readDouble(offset)) as P;
+    case 5:
       return (reader.readString(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -737,6 +746,75 @@ extension BookQueryFilter on QueryBuilder<Book, Book, QFilterCondition> {
     });
   }
 
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'lastRead',
+      ));
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'lastRead',
+      ));
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadEqualTo(
+      DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'lastRead',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'lastRead',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'lastRead',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterFilterCondition> lastReadBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'lastRead',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Book, Book, QAfterFilterCondition> progressEqualTo(
     double value, {
     double epsilon = Query.epsilon,
@@ -1081,6 +1159,18 @@ extension BookQuerySortBy on QueryBuilder<Book, Book, QSortBy> {
     });
   }
 
+  QueryBuilder<Book, Book, QAfterSortBy> sortByLastRead() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastRead', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterSortBy> sortByLastReadDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastRead', Sort.desc);
+    });
+  }
+
   QueryBuilder<Book, Book, QAfterSortBy> sortByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'progress', Sort.asc);
@@ -1155,6 +1245,18 @@ extension BookQuerySortThenBy on QueryBuilder<Book, Book, QSortThenBy> {
     });
   }
 
+  QueryBuilder<Book, Book, QAfterSortBy> thenByLastRead() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastRead', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Book, Book, QAfterSortBy> thenByLastReadDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'lastRead', Sort.desc);
+    });
+  }
+
   QueryBuilder<Book, Book, QAfterSortBy> thenByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'progress', Sort.asc);
@@ -1202,6 +1304,12 @@ extension BookQueryWhereDistinct on QueryBuilder<Book, Book, QDistinct> {
     });
   }
 
+  QueryBuilder<Book, Book, QDistinct> distinctByLastRead() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'lastRead');
+    });
+  }
+
   QueryBuilder<Book, Book, QDistinct> distinctByProgress() {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'progress');
@@ -1238,6 +1346,12 @@ extension BookQueryProperty on QueryBuilder<Book, Book, QQueryProperty> {
   QueryBuilder<Book, String, QQueryOperations> filePathProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'filePath');
+    });
+  }
+
+  QueryBuilder<Book, DateTime?, QQueryOperations> lastReadProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'lastRead');
     });
   }
 

--- a/lib/providers/book_provider.dart
+++ b/lib/providers/book_provider.dart
@@ -11,9 +11,18 @@ class BookProvider extends ChangeNotifier {
   List<Book> _books = [];
   List<Book> get books => List.unmodifiable(_books);
 
+  void _sortBooks() {
+    _books.sort((a, b) {
+      final aTime = a.lastRead ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bTime = b.lastRead ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return bTime.compareTo(aTime);
+    });
+  }
+
   /// Load books from the repository into memory.
   Future<void> loadBooks() async {
     _books = await _repository.getAllBooks();
+    _sortBooks();
     notifyListeners();
   }
 
@@ -21,6 +30,7 @@ class BookProvider extends ChangeNotifier {
   Future<void> addBook(Book book) async {
     await _repository.addBook(book);
     _books.add(book);
+    _sortBooks();
     notifyListeners();
   }
 
@@ -31,6 +41,7 @@ class BookProvider extends ChangeNotifier {
     if (index != -1) {
       _books[index] = book;
     }
+    _sortBooks();
     notifyListeners();
   }
 

--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:kindle_clone_v2/models/book.dart';
 import 'package:kindle_clone_v2/models/highlight.dart';
 import 'package:kindle_clone_v2/repositories/book_repository.dart';
+import 'package:provider/provider.dart';
 import 'package:pdfrx/pdfrx.dart';
 import 'package:flutter/services.dart';
+import 'package:kindle_clone_v2/providers/book_provider.dart';
 
 class PDFViewerScreen extends StatefulWidget {
   final Book bookDetail; // Can also be a URL
@@ -29,6 +31,8 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
   void initState() {
     super.initState();
     _loadHighlights();
+    widget.bookDetail.lastRead = DateTime.now();
+    context.read<BookProvider>().updateBook(widget.bookDetail);
   }
 
   Future<void> _loadHighlights() async {


### PR DESCRIPTION
## Summary
- show reading progress as percentage and highlight the most recently read book
- track when a book is opened by storing `lastRead`
- sort the library by last read time
- apply rainbow progress bar for the last read book

## Testing
- `flutter pub run build_runner build --delete-conflicting-outputs`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_685cbfb9832c832b884a945433838f6d