### PR TITLE
Implement bottom sheet for note entry

### DIFF
--- a/lib/screens/pdf_viewer_screen.dart
+++ b/lib/screens/pdf_viewer_screen.dart
@@ -101,27 +101,53 @@ class _PDFViewerScreenState extends State<PDFViewerScreen> {
       });
     } else if (result == 'add') {
       final controller = TextEditingController();
-      final note = await showDialog<String>(
+      final note = await showModalBottomSheet<String>(
         context: context,
-        builder:
-            (ctx) => AlertDialog(
-              title: const Text('Add Comment'),
-              content: TextField(
-                controller: controller,
-                autofocus: true,
-                decoration: const InputDecoration(hintText: 'Enter comment'),
-              ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.pop(ctx),
-                  child: const Text('Cancel'),
+        isScrollControlled: true,
+        builder: (ctx) {
+          return Padding(
+            padding: EdgeInsets.only(
+              left: 16,
+              right: 16,
+              top: 16,
+              bottom: MediaQuery.of(ctx).viewInsets.bottom + 16,
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: controller,
+                  autofocus: true,
+                  maxLines: null,
+                  decoration: const InputDecoration(
+                    hintText: 'Add your notes here...',
+                  ),
                 ),
-                TextButton(
-                  onPressed: () => Navigator.pop(ctx, controller.text.trim()),
-                  child: const Text('Save'),
+                const SizedBox(height: 12),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx),
+                      child: const Text('Cancel'),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.blue,
+                        foregroundColor: Colors.white,
+                      ),
+                      onPressed: () =>
+                          Navigator.pop(ctx, controller.text.trim()),
+                      child: const Text('Submit'),
+                    ),
+                  ],
                 ),
               ],
             ),
+          );
+        },
       );
       if (note != null && note.isNotEmpty) {
         highlight.notes = [...highlight.notes, note];


### PR DESCRIPTION
## Summary
- refactor `_onHighlightTap` so adding a comment opens a bottom sheet
- show multi-line note field with Cancel and Submit actions

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68674fc868b8832bb7c81d13803303c7